### PR TITLE
Only display the service name

### DIFF
--- a/fragments/navigation.gohtml
+++ b/fragments/navigation.gohtml
@@ -20,7 +20,7 @@
             {{if $element.Metadata.HasDoc}}
             <li>
                 <a class="{{$class}}" href="{{$.Prefix}}doc/{{$svc.Namespace}}/{{$svc.Name}}">
-                    {{$svc.Namespace}}.{{$svc.Name}}
+                    {{$svc.Name}}
                 </a>
             </li>
             {{end}}


### PR DESCRIPTION
We don't need to expose information on the namespace the service runs in